### PR TITLE
Fix: temporarily disable the param `spill_thr`

### DIFF
--- a/SIAB/spillage/pytorch_swat/main.py
+++ b/SIAB/spillage/pytorch_swat/main.py
@@ -268,11 +268,11 @@ Max steps: {info_opt.max_steps}
             # add the convergence condition here, while for old version the optimization
             # will proceed until the max step is reached. However observed that the optimization
             # will converge in a few steps.
-            if _dspill <= spill_thr:
-                print(f"...\nSpillage meets convergence threshold {spill_thr} ({_dspill}) at step {istep}.", flush=True)
-                break
-            if istep == maxSteps-1:
-                print(f"...\nWARNING: Spillage optimization reaches the maximum steps {maxSteps} without convergence ({spill_thr}).", flush=True)
+            # if abs(_dspill) <= spill_thr:
+            #     print(f"...\nSpillage meets convergence threshold {spill_thr} ({abs(_dspill)}) at step {istep}.", flush=True)
+            #     break
+            # if istep == maxSteps-1:
+            #     print(f"...\nWARNING: Spillage optimization reaches the maximum steps {maxSteps} without convergence ({spill_thr}).", flush=True)
 
     orb = sspso.generate_orbital(info_element, C_old, E)
     # this is a ad hoc way to smooth the orbital. A more clean way would be implemented

--- a/SIAB_INPUT.json
+++ b/SIAB_INPUT.json
@@ -12,9 +12,8 @@
 
     "optimizer": "pytorch.SWAT",
     "max_steps": 1000,
-    "spill_coefs": [2.0, 1.0],
+    "spill_coefs": [0.0, 1.0],
     "spill_guess": "atomic",
-    "spill_thr": 1e-8,
     "nthreads_rcut": 4,
 
     "reference_systems": [


### PR DESCRIPTION
due to it is SWATs, stochastic SD, therefore the convergence threshold may not be correct for it