### PR TITLE
Feature: support jY basis direct output

### DIFF
--- a/SIAB/SIAB_nouvelle.py
+++ b/SIAB/SIAB_nouvelle.py
@@ -150,6 +150,8 @@ def run(fname: str,
                          env_settings=env_settings,
                          test=test)
     
+# TODO: Remove `siab_version` in future versions as it will be deprecated
+sdf.spillage(folders=folders, calculation_settings=calculation_settings, siab_settings=siab_settings, siab_version=siab_version)
     # then call optimizer
     # in new version, the original pytorch.SWAT is moved into folder spillage, as one of the
     # submodules of spillage. 

--- a/SIAB/SIAB_nouvelle.py
+++ b/SIAB/SIAB_nouvelle.py
@@ -133,6 +133,13 @@ def run(fname: str,
     structures, calculation_settings,\
     siab_settings, env_settings, general = sdf.initialize(fname=fname, version=siab_version)
 
+    # there is a development option that if "optimizer": None, will only output the
+    # jY basis together with ecutwfc, rcuts, lmax for each structure.
+    # this is quite useful for exploring the completeness limit of this construction
+    # of basis, if lmax is set very high.
+    shortcut = sdf.shortcut_to_jY(calculation_settings, siab_settings)
+    if shortcut == "shortcut": return
+
     # ABACUS corresponding refactor has done supporting multiple bessel_nao_rcut input
     # `folders` contains the folders for each reference shape, is a list of list of str.
     # The first dimension is the same as reference_shapes, the second dimension is the

--- a/SIAB/SIAB_nouvelle.py
+++ b/SIAB/SIAB_nouvelle.py
@@ -149,15 +149,14 @@ def run(fname: str,
                          calculation_settings=calculation_settings,
                          env_settings=env_settings,
                          test=test)
-    
-# TODO: Remove `siab_version` in future versions as it will be deprecated
-sdf.spillage(folders=folders, calculation_settings=calculation_settings, siab_settings=siab_settings, siab_version=siab_version)
+
     # then call optimizer
     # in new version, the original pytorch.SWAT is moved into folder spillage, as one of the
     # submodules of spillage. 
     # `siab_version` is a temporary parameter, for directly calling the optimizer in spillage/
     # pytorch_swat. For future versions, this parameter will be removed, and `optimizer`
     # in `siab_settings` will be used to call corresponding optimizer.
+    # TODO: Remove `siab_version` in future versions as it will be deprecated
     sdf.spillage(folders=folders,
                  calculation_settings=calculation_settings,
                  siab_settings=siab_settings,

--- a/SIAB/SIAB_nouvelle.py
+++ b/SIAB/SIAB_nouvelle.py
@@ -138,7 +138,8 @@ def run(fname: str,
     # this is quite useful for exploring the completeness limit of this construction
     # of basis, if lmax is set very high.
     shortcut = sdf.shortcut_to_jY(calculation_settings, siab_settings)
-    if shortcut == "shortcut": return
+    if shortcut == "shortcut":
+        return
 
     # ABACUS corresponding refactor has done supporting multiple bessel_nao_rcut input
     # `folders` contains the folders for each reference shape, is a list of list of str.

--- a/SIAB/SIAB_nouvelle.py
+++ b/SIAB/SIAB_nouvelle.py
@@ -133,14 +133,6 @@ def run(fname: str,
     structures, calculation_settings,\
     siab_settings, env_settings, general = sdf.initialize(fname=fname, version=siab_version)
 
-    # there is a development option that if "optimizer": None, will only output the
-    # jY basis together with ecutwfc, rcuts, lmax for each structure.
-    # this is quite useful for exploring the completeness limit of this construction
-    # of basis, if lmax is set very high.
-    shortcut = sdf.shortcut_to_jY(calculation_settings, siab_settings)
-    if shortcut == "shortcut":
-        return
-
     # ABACUS corresponding refactor has done supporting multiple bessel_nao_rcut input
     # `folders` contains the folders for each reference shape, is a list of list of str.
     # The first dimension is the same as reference_shapes, the second dimension is the
@@ -157,6 +149,7 @@ def run(fname: str,
                          calculation_settings=calculation_settings,
                          env_settings=env_settings,
                          test=test)
+    
     # then call optimizer
     # in new version, the original pytorch.SWAT is moved into folder spillage, as one of the
     # submodules of spillage. 

--- a/SIAB/driver/front.py
+++ b/SIAB/driver/front.py
@@ -137,7 +137,7 @@ def shortcut_to_jY(calculation_settings: list,
                    siab_settings) -> str:
     """produce jY basis directly"""
     optimizer = siab_settings.get("optimizer", "pytorch.SWAT")
-    optimizer = None if str(optimizer).lower() == "none" else optimizer
+    optimizer = None if optimizer is None or str(optimizer).strip().lower() == "none" else optimizer
     if optimizer:
         return "no shortcut"
     # shortcut case

--- a/SIAB/driver/front.py
+++ b/SIAB/driver/front.py
@@ -132,3 +132,14 @@ def spillage(folders: list,
         ss_api.iter(siab_settings, calculation_settings, folders)
     return
 
+# shortcut for case optimizer = None, produce jY basis directly
+def shortcut_to_jY(calculation_settings: list,
+                   siab_settings) -> str:
+    """produce jY basis directly"""
+    optimizer = siab_settings.get("optimizer", "pytorch.SWAT")
+    optimizer = None if optimizer in ["none", "None", None] else optimizer
+    if optimizer:
+        return "no shortcut"
+    # shortcut case
+    ss_api.iter_jY(calculation_settings, siab_settings)
+    return "shortcut"

--- a/SIAB/driver/front.py
+++ b/SIAB/driver/front.py
@@ -125,9 +125,10 @@ def spillage(folders: list,
     ```
     """
     # iteratively generate numerical atomic orbitals here
-    optimizer = siab_settings.get("optimizer", "none")
-    if optimizer == "pytorch.SWAT":
+    optimizer = siab_settings.get("optimizer", "none").lower()
+    if optimizer in ["pytorch.swat"]:
         ssps_api.iter(siab_settings, calculation_settings)
-    else:
+    elif optimizer in ["none", "restart", "bfgs"]:
         ss_api.iter(siab_settings, calculation_settings, folders)
-    return
+    else:
+        raise ValueError(f"Unsupported optimizer setting: {optimizer}")

--- a/SIAB/driver/front.py
+++ b/SIAB/driver/front.py
@@ -137,7 +137,7 @@ def shortcut_to_jY(calculation_settings: list,
                    siab_settings) -> str:
     """produce jY basis directly"""
     optimizer = siab_settings.get("optimizer", "pytorch.SWAT")
-    optimizer = None if optimizer in ["none", "None", None] else optimizer
+    optimizer = None if str(optimizer).lower() == "none" else optimizer
     if optimizer:
         return "no shortcut"
     # shortcut case

--- a/SIAB/driver/front.py
+++ b/SIAB/driver/front.py
@@ -125,21 +125,9 @@ def spillage(folders: list,
     ```
     """
     # iteratively generate numerical atomic orbitals here
-    optimizer = siab_settings.get("optimizer", "pytorch.SWAT")
+    optimizer = siab_settings.get("optimizer", "none")
     if optimizer == "pytorch.SWAT":
-        ssps_api.iter(siab_settings=siab_settings, calculation_settings=calculation_settings)
-    elif optimizer == "bfgs":
+        ssps_api.iter(siab_settings, calculation_settings)
+    else:
         ss_api.iter(siab_settings, calculation_settings, folders)
     return
-
-# shortcut for case optimizer = None, produce jY basis directly
-def shortcut_to_jY(calculation_settings: list,
-                   siab_settings) -> str:
-    """produce jY basis directly"""
-    optimizer = siab_settings.get("optimizer", "pytorch.SWAT")
-    optimizer = None if optimizer is None or str(optimizer).strip().lower() == "none" else optimizer
-    if optimizer:
-        return "no shortcut"
-    # shortcut case
-    ss_api.iter_jY(calculation_settings, siab_settings)
-    return "shortcut"

--- a/SIAB/interface/abacus.py
+++ b/SIAB/interface/abacus.py
@@ -330,7 +330,8 @@ def run_all(general: dict,
     element = general["element"]
     folders = []
     if general.get("skip_abacus", False):
-        print("INFO: required by orbital generation setting the \'optimizer\' = \'none\'/\'restart\', skip abacus.", flush=True)
+        # Skipping calculations as per the configuration to optimize performance
+        print("INFO: required by orbital generation setting the 'optimizer' = 'none'/'restart', skip abacus.", flush=True)
         return [[f"{element}-virtual-folder"]]
     for isp, shape in enumerate(structures):
         shape, bond_lengths = shape

--- a/SIAB/interface/abacus.py
+++ b/SIAB/interface/abacus.py
@@ -329,6 +329,9 @@ def run_all(general: dict,
     """iterately calculate planewave wavefunctions for reference shapes and bond lengths"""
     element = general["element"]
     folders = []
+    if general.get("skip_abacus", False):
+        print("INFO: required by orbital generation setting the \'optimizer\' = \'none\'/\'restart\', skip abacus.", flush=True)
+        return [[f"{element}-virtual-folder"]]
     for isp, shape in enumerate(structures):
         shape, bond_lengths = shape
         folders_istructure = []

--- a/SIAB/io/read_input.py
+++ b/SIAB/io/read_input.py
@@ -388,7 +388,8 @@ def description(symbol: str, user_settings: dict):
     return {
         "element": symbol,
         "pseudo_dir": user_settings["pseudo_dir"],
-        "pseudo_name": user_settings["pseudo_name"]
+        "pseudo_name": user_settings["pseudo_name"],
+        "skip_abacus": user_settings.get("optimizer") in ["none", "restart"]
     }
 
 def unpack_siab_input(user_settings: dict, pseudopotential: dict):

--- a/SIAB/spillage/api.py
+++ b/SIAB/spillage/api.py
@@ -1,6 +1,43 @@
 """this file defines interface between newly implemented spillage optimization algorithm
 with the driver of SIAB"""
-def orbgen_of_rcut(rcut: float, siab_settings: dict, folders: list):
+
+def _coef_gen(rcut: float, ecut: float, lmax: int, value: str = "eye"):
+    """Directly generate the coefficients of the orbitals instead of performing optimization
+    
+    Args:
+    rcut: float
+        the cutoff radius
+    ecut: float
+        the energy cutoff
+    lmax: int
+        the maximum angular momentum
+    value: str
+        the value to be generated, can be "eye"
+
+    Returns:
+    list of list of list of list of float: the coefficients of the orbitals
+    """
+    from SIAB.spillage.spillage import _nbes
+    import numpy as np
+    if not isinstance(ecut, (int, float)):
+        raise ValueError("Expected ecut to be an integer or float")
+    if not isinstance(lmax, int):
+        raise ValueError("Expected lmax to be an integer")
+    if not isinstance(value, str):
+        raise ValueError("Expected value to be a string")
+    
+    nbes_rcut = [_nbes(l, rcut, ecut) for l in range(lmax + 1)]
+    if value == "eye":
+        return [[np.eye(nbes_rcut[l]).tolist() for l in range(lmax + 1)]]
+    else:
+        raise ValueError("Only 'eye' is supported for value presently")
+
+def _coef_restart(fcoef: str):
+    """get coefficients from SIAB dumped ORBITAL_RESULTS.txt file"""
+    from SIAB.spillage.orbio import read_param
+    return read_param(fcoef)
+
+def _coef_opt(rcut: float, siab_settings: dict, folders: list):
     """generate orbitals for one single rcut value"""
     import os
     import numpy as np
@@ -20,7 +57,7 @@ def orbgen_of_rcut(rcut: float, siab_settings: dict, folders: list):
     # load orb_matix with correct rcut
     fov = None
     for folder in folders:
-        for fov_, fop_ in orb_matrices(folder):
+        for fov_, fop_ in _orb_matrices(folder):
             ov, op = map(read_orb_mat, [fov_, fop_])
             assert ov['rcut'] == op['rcut'], "Data violation: rcut of ov and op matrices are different"
             if np.abs(ov['rcut'] - rcut) < 1e-10:
@@ -54,33 +91,19 @@ def orbgen_of_rcut(rcut: float, siab_settings: dict, folders: list):
         print(f"""ORBGEN: optimization on level {iorb + 1} (with # of zeta functions for each l: {orb['nzeta']}), 
         based on orbital ({orb['nzeta_from']})""", flush = True)
         coef_inner = coefs[iorbs_ref[iorb]] if iorbs_ref[iorb] is not None else None
-        coefs_shell = orbgen.opt(coefs_subset(orb['nzeta'], orb['nzeta_from'], coefs_init), coef_inner, iconfs[iorb], range(orb['nbands_ref']), options, nthreads)
+        coefs_shell = orbgen.opt(_coefs_subset(orb['nzeta'], orb['nzeta_from'], coefs_init), coef_inner, iconfs[iorb], range(orb['nbands_ref']), options, nthreads)
         coefs[iorb] = merge(coef_inner, coefs_shell, 2) if coef_inner is not None else coefs_shell
         print(f"ORBGEN: End optimization on level {iorb + 1} orbital, merge with previous orbital shell(s).", flush = True)
     return coefs
 
-def iter(siab_settings: dict, calculation_settings: list, folders: list):
-    """Loop over rcut values and yield orbitals"""
-    rcuts = calculation_settings[0]["bessel_nao_rcut"]
-    rcuts = [rcuts] if not isinstance(rcuts, list) else rcuts
-    for rcut in rcuts: # can be parallelized here
-        coefs_tot = orbgen_of_rcut(rcut, siab_settings, folders)
-        # because element does not really matter when optimizing orbitals, the only thing
-        # has element information is the name of folder. So we extract the element from the
-        # first folder name. Not elegant, we know.
-        save_orb(coefs_tot, folders[0][0].split("-")[0], calculation_settings[0]["ecutwfc"],
-                 rcut, [orb['nzeta'] for orb in siab_settings['orbitals']],
-                 siab_settings.get('jY_type', "reduced"))
-    return
-
-def peel(coef, nzeta_lvl_tot):
+def _peel(coef, nzeta_lvl_tot):
     from copy import deepcopy
     coef_lvl = [deepcopy(coef)]
     for nzeta_lvl in reversed(nzeta_lvl_tot):
         coef_lvl.append([[coef_lvl[-1][l].pop(0) for _ in range(nzeta)] for l,nzeta in enumerate(nzeta_lvl)])
     return coef_lvl[1:][::-1]
 
-def coefs_subset(nzeta, nzeta0, data):
+def _coefs_subset(nzeta, nzeta0, data):
     """
     Compare `nzeta` and `nzeta0`, get the subset of `data` that `nzeta` has but
     `nzeta0` does not have. Returned nested list has dimension:
@@ -101,7 +124,7 @@ def coefs_subset(nzeta, nzeta0, data):
     #               l  zeta                 l  list of zeta
     return [[[ data[l][j] for j in jz ] for l, jz in enumerate(iz_subset)]]
 
-def orb_matrices(folder: str):
+def _orb_matrices(folder: str):
     import os
     import re
     """
@@ -143,10 +166,9 @@ def orb_matrices(folder: str):
     for f in files:
         yield f
 
-def save_orb(coefs_tot, elem, ecut, rcut, nzeta, jY_type: str = "reduced"):
+def _save_orb(coefs_tot, elem, ecut, rcut, nzeta, jY_type: str = "reduced"):
     import numpy as np
     import matplotlib.pyplot as plt
-    from SIAB.spillage.radial import build_reduced, build_raw, coeff_normalized2raw
     from SIAB.spillage.plot import plot_chi
     from SIAB.spillage.orbio import write_nao, write_param
     import os, uuid
@@ -160,11 +182,8 @@ def save_orb(coefs_tot, elem, ecut, rcut, nzeta, jY_type: str = "reduced"):
 
     for i, coefs in enumerate(coefs_tot): # loop over all levels of orbitals
         assert len(coefs) == 1, "multiple elements?"
-        if jY_type in ["reduced", "nullspace", "svd"]:
-            chi = build_reduced(coefs[0], rcut, r, True) # the first param should be [l][zeta][q]
-        else:
-            coeff_raw = coeff_normalized2raw(coefs, rcut)
-            chi = build_raw(coeff_raw[0], rcut, r, 0.0, True, True)
+
+        chi = _build_orb(coefs, rcut, 0.01, jY_type)
 
         syms = "SPDFGHIKLMNOQRTUVWXYZ".lower()
         nz = nzeta[i]
@@ -184,61 +203,60 @@ def save_orb(coefs_tot, elem, ecut, rcut, nzeta, jY_type: str = "reduced"):
         os.rename(fparam, os.path.join(f"{folder}/{subfolder}", "ORBITAL_RESULTS.txt"))
         print(f"orbital saved as {forb}")
 
-def jYgen_of_rcut(rcut: float, ecut: float, lmax: int, jY_type: str = "reduced"):
-    """generate jY basis instead of zeta (the linearly combined jY). Or say the zeta 
-    function now is jY itself, the number of zeta for each l is substituted with nbes_rcut"""
+def _build_orb(coefs, rcut, dr: float = 0.01, jY_type: str = "reduced"):
+    """build real space grid orbital based on the coefficients of the orbitals,
+    rcut and grid spacing dr. The coefficients should be in the form of
+    [it][l][zeta][q].
+    
+    Args:
+    coefs: list of list of list of list of float
+        the coefficients of the orbitals
+    rcut: float
+        the cutoff radius
+    dr: float
+        the grid spacing
+    jY_type: str
+        the type of jY basis, can be "reduced", "nullspace", "svd" or "raw"
+
+    Returns:
+    np.ndarray: the real space grid data
+    """
     from SIAB.spillage.radial import build_raw, build_reduced, coeff_normalized2raw
-    from SIAB.spillage.spillage import _nbes
     import numpy as np
 
-    if not isinstance(ecut, (int, float)):
-        raise ValueError("Expected ecut to be an integer or float")
-    if not isinstance(lmax, int):
-        raise ValueError("Expected lmax to be an integer")
-    if not isinstance(jY_type, str):
-        raise ValueError("Expected jY_type to be a string")
-
-    nbes_rcut = [_nbes(l, rcut, ecut) for l in range(lmax + 1)] # calculate the number of "zeta" for each l
-    r = np.linspace(0, rcut, int(rcut/0.01)+1) # dr is hard-coded to 0.01
-    # then coefs will be, still [it][l][ibes][q], but q now should be identity, which means
-    # each [it][l] is a np.eye(nbes_rcut[l])
-    coefs = [[np.eye(nbes_rcut[l]).tolist() for l in range(lmax + 1)]]
+    r = np.linspace(0, rcut, int(rcut/dr)+1) # hard code dr to be 0.01? no...
     if jY_type in ["reduced", "nullspace", "svd"]:
         chi = build_reduced(coefs[0], rcut, r, True)
     else:
-        coeff_raw = coeff_normalized2raw(coefs, rcut)
-        chi = build_raw(coeff_raw[0], rcut, r, 0.0, True, True)
+        coefs = coeff_normalized2raw(coefs, rcut)
+        chi = build_raw(coefs[0], rcut, r, 0.0, True, True)
     return chi
-def iter_jY(calculation_settings: list, siab_settings: dict):
-    """Loop over rcut values and yield jY basis"""
-    import os
-    import uuid
-    import numpy as np
-    import matplotlib.pyplot as plt
-    from SIAB.spillage.plot import plot_chi
-    from SIAB.spillage.orbio import write_nao, write_param
+
+def iter(siab_settings: dict, calculation_settings: list, folders: list):
+    """Loop over rcut values and yield orbitals"""
     rcuts = calculation_settings[0]["bessel_nao_rcut"]
-    ecut = calculation_settings[0]["ecutwfc"]
     rcuts = [rcuts] if not isinstance(rcuts, list) else rcuts
+    ecut = calculation_settings[0]["ecutwfc"]
+    elem = folders[0][0].split("-")[0]
+    # because element does not really matter when optimizing orbitals, the only thing
+    # has element information is the name of folder. So we extract the element from the
+    # first folder name. Not elegant, we know.
+    jY_type = siab_settings.get("jY_type", "reduced")
+
+    run_map = {"none": "none", "restart": "restart", "bfgs": "opt"}
+    run_type = run_map.get(siab_settings.get("optimizer", "none"), "none")
     for rcut in rcuts: # can be parallelized here
-        r = np.linspace(0, rcut, int(rcut/0.01)+1) # dr is hard-coded to 0.01
-        for orb in siab_settings["orbitals"]: # loop over different levels
-            lmax = len(orb["nzeta"]) - 1
-            chi = jYgen_of_rcut(rcut, ecut, lmax, siab_settings.get("jY_type", "reduced"))
-            folder, subfolder = f"jY_lmax{lmax}", f"{rcut}au_{ecut}Ry"
-            os.makedirs(f"{folder}/{subfolder}", exist_ok=True)
-            fpng = f"jY_lmax{lmax}_{rcut}au_{ecut}Ry.png"
-            plot_chi(chi, r, save=fpng)
-            os.rename(fpng, os.path.join(f"{folder}/{subfolder}", fpng))
-            plt.close()
-            print(f"jY basis saved as {fpng}")
-            forb = fpng.replace(".png", ".orb")
-            write_nao(forb, "jY", ecut, rcut, len(r), 0.01, chi)
-            os.rename(forb, os.path.join(f"{folder}/{subfolder}", forb))
-            print(f"orbital saved as {forb}")
-            fparam = str(uuid.uuid4())
-            write_param(fparam, chi, rcut, 0.01, "jY")
-            os.rename(fparam, os.path.join(f"{folder}/{subfolder}", "ORBITAL_RESULTS.txt"))
+        if run_type == "opt":
+            coefs_tot = _coef_opt(rcut, siab_settings, folders)
+            nzeta = [orb['nzeta'] for orb in siab_settings['orbitals']]
+        elif run_type == "restart":
+            nzeta = None # here it is actually unreachable, so give as None
+            raise NotImplementedError("restart is not implemented yet")
+        else:
+            coefs_tot = [_coef_gen(rcut, ecut, len(orb['nzeta']) - 1) for orb in siab_settings['orbitals']]
+            nzeta = [[len(shell) for shell in coefs[0]] for coefs in coefs_tot]
+
+        _save_orb(coefs_tot, elem, ecut, rcut, nzeta, jY_type)
     return
 
 import unittest
@@ -253,13 +271,13 @@ class TestAPI(unittest.TestCase):
             f.write("old version")
         # expect an assertion error
         with self.assertRaises(AssertionError):
-            for files in orb_matrices(test_folder):
+            for files in _orb_matrices(test_folder):
                 pass
         # continue to write orb_matrix.1.dat
         with open(os.path.join(test_folder, "orb_matrix.1.dat"), "w") as f:
             f.write("old version")
         # will not raise an error, but return orb_matrix.0.dat and orb_matrix.1.dat
-        for files in orb_matrices(test_folder):
+        for files in _orb_matrices(test_folder):
             self.assertEqual(files, 
             (os.path.join(test_folder, "orb_matrix.0.dat"), 
              os.path.join(test_folder, "orb_matrix.1.dat")))
@@ -268,20 +286,20 @@ class TestAPI(unittest.TestCase):
             f.write("new version")
         # expect an assertion error due to coexistence of old and new files
         with self.assertRaises(AssertionError):
-            for files in orb_matrices(test_folder):
+            for files in _orb_matrices(test_folder):
                 pass
         # continue to write new files
         with open(os.path.join(test_folder, "orb_matrix_rcut6deriv1.dat"), "w") as f:
             f.write("new version")
         # expect an assertion error due to coexistence of old and new files
         with self.assertRaises(AssertionError):
-            for files in orb_matrices(test_folder):
+            for files in _orb_matrices(test_folder):
                 pass
         # remove old files
         os.remove(os.path.join(test_folder, "orb_matrix.0.dat"))
         os.remove(os.path.join(test_folder, "orb_matrix.1.dat"))
         # now will return new files
-        for files in orb_matrices(test_folder):
+        for files in _orb_matrices(test_folder):
             self.assertEqual(files, 
             (os.path.join(test_folder, "orb_matrix_rcut6deriv0.dat"), 
              os.path.join(test_folder, "orb_matrix_rcut6deriv1.dat")))
@@ -290,13 +308,13 @@ class TestAPI(unittest.TestCase):
             f.write("new version")
         # expect an assertion error due to odd number of new files
         with self.assertRaises(AssertionError):
-            for files in orb_matrices(test_folder):
+            for files in _orb_matrices(test_folder):
                 pass
         # continue to write new files
         with open(os.path.join(test_folder, "orb_matrix_rcut7deriv1.dat"), "w") as f:
             f.write("new version")
         # now will return new files
-        for ifmats, fmats in enumerate(orb_matrices(test_folder)):
+        for ifmats, fmats in enumerate(_orb_matrices(test_folder)):
             if ifmats == 0:
                 self.assertEqual(fmats, 
             (os.path.join(test_folder, "orb_matrix_rcut6deriv0.dat"), 
@@ -335,51 +353,51 @@ class TestAPI(unittest.TestCase):
         nz1 = [1, 1]
         data = [np.random.random(i).tolist() for i in nz3]
         
-        subset = coefs_subset(nz1, None, data)
+        subset = _coefs_subset(nz1, None, data)
         self.assertEqual(subset, [[[data[0][0]], 
                                    [data[1][0]]]])
 
-        subset = coefs_subset(nz2, None, data)
+        subset = _coefs_subset(nz2, None, data)
         self.assertEqual(subset, [[[data[0][0], data[0][1]], 
                                    [data[1][0], data[1][1]],
                                    [data[2][0]]
                                   ]])
 
-        subset = coefs_subset(nz3, None, data)
+        subset = _coefs_subset(nz3, None, data)
         self.assertEqual(subset, [[[data[0][0], data[0][1], data[0][2]], 
                                    [data[1][0], data[1][1], data[1][2]],
                                    [data[2][0], data[2][1]]
                                   ]])
 
-        subset = coefs_subset(nz3, nz2, data)
+        subset = _coefs_subset(nz3, nz2, data)
         self.assertEqual(subset, [[[data[0][2]], 
                                    [data[1][2]], 
                                    [data[2][1]]]])
         
-        subset = coefs_subset(nz2, nz1, data)
+        subset = _coefs_subset(nz2, nz1, data)
         self.assertEqual(subset, [[[data[0][1]], 
                                    [data[1][1]], 
                                    [data[2][0]]]])
         
-        subset = coefs_subset(nz3, nz1, data)
+        subset = _coefs_subset(nz3, nz1, data)
         self.assertEqual(subset, [[[data[0][1], data[0][2]], 
                                    [data[1][1], data[1][2]], 
                                    [data[2][0], data[2][1]]]])
         
         nz2 = [1, 2, 1]
-        subset = coefs_subset(nz3, nz2, data)
+        subset = _coefs_subset(nz3, nz2, data)
         self.assertEqual(subset, [[[data[0][1], data[0][2]], 
                                    [data[1][2]], 
                                    [data[2][1]]]])
 
-        subset = coefs_subset(nz3, nz3, data)
+        subset = _coefs_subset(nz3, nz3, data)
         self.assertEqual(subset, [[[], [], []]])
         
         with self.assertRaises(AssertionError):
-            subset = coefs_subset(nz1, nz3, data) # nz1 < nz3
+            subset = _coefs_subset(nz1, nz3, data) # nz1 < nz3
 
         with self.assertRaises(AssertionError):
-            subset = coefs_subset(nz2, nz3, data) # nz2 < nz3
+            subset = _coefs_subset(nz2, nz3, data) # nz2 < nz3
 
 if __name__ == "__main__":
     unittest.main()

--- a/SIAB/spillage/api.py
+++ b/SIAB/spillage/api.py
@@ -190,6 +190,14 @@ def jYgen_of_rcut(rcut: float, ecut: float, lmax: int, jY_type: str = "reduced")
     from SIAB.spillage.radial import build_raw, build_reduced, coeff_normalized2raw
     from SIAB.spillage.spillage import _nbes
     import numpy as np
+
+    if not isinstance(ecut, (int, float)):
+        raise ValueError("Expected ecut to be an integer or float")
+    if not isinstance(lmax, int):
+        raise ValueError("Expected lmax to be an integer")
+    if not isinstance(jY_type, str):
+        raise ValueError("Expected jY_type to be a string")
+
     nbes_rcut = [_nbes(l, rcut, ecut) for l in range(lmax + 1)] # calculate the number of "zeta" for each l
     r = np.linspace(0, rcut, int(rcut/0.01)+1) # dr is hard-coded to 0.01
     # then coefs will be, still [it][l][ibes][q], but q now should be identity, which means
@@ -201,7 +209,6 @@ def jYgen_of_rcut(rcut: float, ecut: float, lmax: int, jY_type: str = "reduced")
         coeff_raw = coeff_normalized2raw(coefs, rcut)
         chi = build_raw(coeff_raw[0], rcut, r, 0.0, True, True)
     return chi
-
 def iter_jY(calculation_settings: list, siab_settings: dict):
     """Loop over rcut values and yield jY basis"""
     import os

--- a/SIAB/spillage/util.py
+++ b/SIAB/spillage/util.py
@@ -24,6 +24,8 @@ def initialize(calculation_settings, siab_settings, folders):
         # therefore this setup is to expand the "folder" key to the corresponding folder
         # list
         i = orbital["folder"] if siab_settings.get("optimizer", "none") not in ["none", "restart"] else 0
+        if i >= len(folders):
+            raise IndexError("Folder index out of range")
         orbital["folder"] = folders[i]
 
     return siab_settings

--- a/SIAB/spillage/util.py
+++ b/SIAB/spillage/util.py
@@ -23,6 +23,7 @@ def initialize(calculation_settings, siab_settings, folders):
         # and the "abacus_setup" is then expanded to the corresponding folder
         # therefore this setup is to expand the "folder" key to the corresponding folder
         # list
-        orbital["folder"] = folders[orbital["folder"]]
+        i = orbital["folder"] if siab_settings.get("optimizer", "none") not in ["none", "restart"] else 0
+        orbital["folder"] = folders[i]
 
     return siab_settings


### PR DESCRIPTION
As requested by IOP that use jY to find the converging limit of GW calculation involving numerical atomic orbital.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a development option to output basis construction information.
	- Added a shortcut for optimizer cases to directly produce a basis.
	- Introduced functions for generating jY basis and iterating over rcut values.

- **Enhancements**
	- Updated `run_all` function to skip abacus calculation under specific conditions.
	- Modified `save_orb` function parameters to improve functionality.

- **Bug Fixes**
	- Improved conditional logic for assigning orbital folders to enhance stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->