### PR TITLE
Fix: update the way to set nbands default

### DIFF
--- a/SIAB/io/read_input.py
+++ b/SIAB/io/read_input.py
@@ -439,10 +439,7 @@ def cal_nbands_fill_lmax(minimal_basis: list, zval: int, lmax: int, fill_lmax: b
     # electrons will fill orbitals like -> H to Og (118)
     seq = ["1S", "2S", "2P", "3S", "3P", "4S", "3D", "4P", "5S", "4D", "5P", "6S", "4F", "5D", "6P", "7S", "5F", "6D", "7P"]
     occ = {"S": 2, "P": 6, "D": 10, "F": 14, "G": 18}
-    # the first and the last element that fills shell of lmax.
-    # S: 1, Hydrogen; P: 5, Boron; D: 21, Scandium; F: 58, Cerium;
-    # S: 2, Helium;   P: 10, Neon; D: 30, Zinc;     F: 70, Ytterbium
-    nelec = [[1, 5, 21, 58], [2, 10, 30, 70]] 
+
     # first flatten the minimal_basis
     flat_basis = [orb for shell in minimal_basis for orb in shell]
     ind = [seq.index(orb) for orb in flat_basis]
@@ -450,11 +447,52 @@ def cal_nbands_fill_lmax(minimal_basis: list, zval: int, lmax: int, fill_lmax: b
     for i in range(max(ind)): # I must proceed in this way because I am not sure if the pseudization of electrons are in order
         if seq[i] not in flat_basis: # which means the electron is pseudized
             core += occ[seq[i][-1]]
-    #print(f"Initial guess: estimated number of electrons pseudized for present pseudopotential: {core}", flush=True)
-    # calculation with pseudopotential can only calculate bands above core electrons, say for K, the first band would be of 3s, ideally
-    idx_nelec = 1 if fill_lmax else 0
-    nbands = max(ceil(zval/2), ceil((nelec[idx_nelec][min(lmax, 3)]-core)/2))
+
+    # the first and the last element that fills shell of lmax.
+    # S: 1, Hydrogen; P: 5, Boron; D: 21, Scandium; F: 58, Cerium;
+    # S: 2, Helium;   P: 10, Neon; D: 30, Zinc;     F: 70, Ytterbium
+    # nelec_max: the maximal number of electrons for each l and each period (can fill up to lmax orbitals)
+    # nelec_min: the minimal number of electrons for each l and each period (can reach to lmax orbitals)
+    nelec_max = [[2, 4, 12, 20, 38, 56, 88, 120], [10, 18, 36, 54, 86, 118], 
+                 [30, 48, 80, 112], [70, 102]]
+    nelec_min = [[1, 3, 11, 19, 37, 55, 87, 119], [5, 13, 31, 49, 81, 113],
+                 [21, 39, 57, 89], [58, 90]]
+    nelec_ref = nelec_max if fill_lmax else nelec_min
+    
+    # for long-sp case, the element always explicit has s and p electrons but has been after the first element that can fill the d
+    # orbital, thus the number of electrons needed to fill d is calculated to be negative number in the past, will result in zval/2
+    # band autoset but is not enough when smearing is switched on. Therefore to sample d orbitals, it is the d in the next period 
+    # rather than the d in the current period that is needed to be filled.
+    print(f"Autoset: adding orbitals... will add electrons to l = {lmax} orbitals according to Hund's rule", flush=True)
+    strategy = "\'fill up to\'" if fill_lmax else "\'reach to\'"
+    print(f"Autoset: strategy {strategy} lmax = {lmax} subshell", flush=True)
+    
+    # there are already some orbitals sampled by minimal basis (valence treated electrons in pseudopotential), thus only those
+    # subshells that are not occupied are needed to be sampled by manually adding electrons/ bands
+    l_occ = [True if len(minimal_basis[i]) > 0 else False for i in range(len(minimal_basis))]
+    assert len(l_occ) <= lmax, "lmax smaller than minimal basis"
+    l_occ = l_occ + [False]*(lmax - len(l_occ))
+    l_tofill = [l for l in range(lmax) if not l_occ[l]]
+
+    nelec_needed = 0
+    for l in l_tofill:
+        if l > 3: 
+            print(f"Warning: l = {l} > 3, but there is no element with g orbitals", flush=True)
+            continue
+        nelec_delta = [n - core for n in nelec_ref[l] if n - core >= 0]
+        nelec_needed = max(nelec_needed, min(nelec_delta))
+        print(f"Autoset: fill l = {l} orbitals, needed # of extra electrons to fill: {nelec_needed}", flush=True)
+    nbands = max(ceil(zval/2), ceil(nelec_needed/2))
+
+    if zval > nelec_needed:
+        print(f"Autoset: zval = {zval} > nelec_needed = {nelec_needed}. But due to smearing, will add additional 5 nbands", flush=True)
+        nbands += 5
+    
+    # for g-orbital case
     nbands *= 5 if lmax > 3 else 1 # for cases there are explicitly treated f-electrons. Because there is no element with g orbitals
+    if lmax > 3: print("Warning: lmax > 3, to sample as much as possible, multiply nbands by 5", flush=True)
+    
+    # for hydrogen case, needed?
     return int(max(nbands, 2)) # for fixing the case of Hydrogen, zval = 1, if lmax = 0, then nbands = 1, which is not enough
 
 ABACUS_INPUT_TEMPLATE = """INPUT_PARAMETERS


### PR DESCRIPTION
## What's changed
see the following stdout for more details:
```
Parsing SIAB input file SIAB_INPUT.json with version 0.1.0

Autoset: # of pseudized electrons estimated to be: 68
Autoset: adding orbitals... will add electrons to l = 3 orbitals according to Hund's rule
Autoset: strategy 'fill up to' lmax = 3 subshell
Autoset: pseudopotential valence treated subshells:  [['6S'], ['6P'], ['5D']]
Autoset: angular momentum of subshells needed to sample additionally: [3]
Autoset: fill (next/not pseudized) l = 3 orbitals, need 19.0 additional electrons

WARNING: since SIAB version 2.1(2024.6.3), the original functionality invoked by value "auto" is replaced by
        "scan", and for dimer the "auto" now will directly use in-built dimer database if available, otherwise will
         fall back to "scan". This warning will be print everytime if "auto" is used. To disable this warning, specify
         directly the "bond_lengths" in any one of following ways:
         1. a list of floats, e.g. [2.0, 2.5, 3.0]
         2. a string "default", which will use default bond length for dimer, and scan for other shapes, for other shapes, will
            fall back to "scan".
         3. a string "scan", which will scan bond lengths for present shape.

DUPLICATE CHECK-1 pass: folder Bi-dimer-2.23 exists
DUPLICATE CHECK-2 pass: INPUT and INPUTw exist
DUPLICATE CHECK-3 pass: INPUT settings are consistent
```

Fix #62 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Improved calculations for the number of bands based on electron configurations, including handling pseudized electrons and smearing effects.
  - Enhanced band calculation logic for various orbitals, including special cases like hydrogen and g-orbitals, ensuring more accurate band sampling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->