### PR TITLE
Fix: correct the upper bound of loop of lmax, no larger than 3 (f-orb)

### DIFF
--- a/SIAB/io/read_input.py
+++ b/SIAB/io/read_input.py
@@ -453,7 +453,7 @@ def cal_nbands_fill_lmax(zval: int, zcore: int, lmax: int, fill_lmax: bool = Tru
         print(f"WARNING: lmax > 3, will add g-orbital, which is not possible for all ground state atoms", flush=True)
     # for all l <= lmax, find the minimal number of electrons that can fill up to lmax orbitals
     nelec = zval
-    for l in range(min(lmax, 4) + 1):
+    for l in range(min(lmax, 3) + 1):
         nelec_l = min([z for z in z_ref[l] if z >= zcore]) - zcore
         nelec = max(nelec, nelec_l)
     print(f"Autoset: minimal number of electrons to fill up to l = {min(lmax, 3)} is {nelec}", flush=True)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the orbital filling loop condition to ensure accurate calculation of the minimal number of electrons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->